### PR TITLE
osd_mam.sv: Fix typo in the comments

### DIFF
--- a/modules/mam/common/osd_mam.sv
+++ b/modules/mam/common/osd_mam.sv
@@ -518,4 +518,4 @@ module osd_mam
    end
 
 
-endmodule // osd_dem_uart
+endmodule // osd_mam


### PR DESCRIPTION
This fixes typo and changes osd_dem_uart --> osd_mam at the end of the module.